### PR TITLE
Add start screen to quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,14 +313,17 @@
         <section id="quiz" class="bg-white p-8 rounded-lg shadow-xl">
             <h2 class="text-3xl font-semibold mb-8 text-center text-blue-700" data-i18n="quizSectionTitle">Wissens-Quiz zur Zwischenprüfung</h2>
             
-            <div class="mb-6 text-center">
-                <label for="num-questions-select" class="mr-2 font-semibold text-blue-700" data-i18n="quiz_numQuestionsLabel">Anzahl der Fragen:</label>
-                <select id="num-questions-select" class="p-2 border border-blue-300 rounded-md bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                    <option value="5">5</option>
-                    <option value="10" selected>10</option>
-                    <option value="15">15</option>
-                    <option value="all" data-i18n="quiz_numQuestionsAll">Alle</option>
-                </select>
+            <div id="quiz-start-screen" class="mb-6 text-center" style="display:none;">
+                <div class="mb-4">
+                    <label for="num-questions-select" class="mr-2 font-semibold text-blue-700" data-i18n="quiz_numQuestionsLabel">Anzahl der Fragen:</label>
+                    <select id="num-questions-select" class="p-2 border border-blue-300 rounded-md bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="5">5</option>
+                        <option value="10" selected>10</option>
+                        <option value="15">15</option>
+                        <option value="all" data-i18n="quiz_numQuestionsAll">Alle</option>
+                    </select>
+                </div>
+                <button id="start-quiz-btn" class="bg-green-500 hover:bg-green-600 text-white py-2 px-6 rounded-md font-semibold" data-i18n="quiz_startButton">Quiz starten</button>
             </div>
 
             <div id="quiz-area" class="quiz-container max-w-2xl mx-auto">

--- a/js/main.js
+++ b/js/main.js
@@ -57,7 +57,7 @@ async function setLanguage(lang) {
         const isQuizSectionCurrentlyRendered = window.getComputedStyle(quizSection).display !== 'none';
 
         if (isQuizSectionCurrentlyRendered && !resultsAreaVisible) {
-             initializeQuizSession(); 
+             showStartScreen();
         } else if (resultsAreaVisible) {
             showResults(); // Re-render results and review with new language
         }
@@ -66,7 +66,7 @@ async function setLanguage(lang) {
         displayQuizError(langTranslations.quizJsonLoading.replace("Lade", "Fehler beim Laden der") + ` quiz_data_${lang}.json. Versuche ${previousLang}...`);
         if (quizDataStore[previousLang]){
             currentQuizData = quizDataStore[previousLang];
-            initializeQuizSession();
+            showStartScreen();
         }
     }
 

--- a/js/quiz_logic.js
+++ b/js/quiz_logic.js
@@ -13,7 +13,7 @@ let quizStartTime = null;
 // const MAX_QUIZ_QUESTIONS = 10; // Wird jetzt durch Dropdown gesteuert
 
 // DOM Elements
-let questionTextEl, optionsContainerEl, feedbackAreaEl, nextQuestionBtn, quizResultsAreaEl, scoreTextEl, restartQuizBtn, questionCounterEl, quizQuestionContainerEl, quizLoadingMessageEl, quizNavigationEl, numQuestionsSelectEl, quizReviewContainerEl, quizReviewAreaEl, quizProgressEl, timerDisplayEl, finalTimeEl, finalTimeWrapperEl;
+let questionTextEl, optionsContainerEl, feedbackAreaEl, nextQuestionBtn, quizResultsAreaEl, scoreTextEl, restartQuizBtn, questionCounterEl, quizQuestionContainerEl, quizLoadingMessageEl, quizNavigationEl, numQuestionsSelectEl, quizReviewContainerEl, quizReviewAreaEl, quizProgressEl, timerDisplayEl, finalTimeEl, finalTimeWrapperEl, startScreenEl, startQuizBtn;
 
 function initializeQuizDOMElements() {
     questionTextEl = document.getElementById('question-text');
@@ -34,6 +34,8 @@ function initializeQuizDOMElements() {
     timerDisplayEl = document.getElementById('quiz-timer');
     finalTimeEl = document.getElementById('final-time');
     finalTimeWrapperEl = document.getElementById('final-time-wrapper');
+    startScreenEl = document.getElementById('quiz-start-screen');
+    startQuizBtn = document.getElementById('start-quiz-btn');
 }
 
 
@@ -107,6 +109,15 @@ function stopQuizTimer() {
     quizTimerInterval = null;
 }
 
+function showStartScreen() {
+    if (startScreenEl) startScreenEl.style.display = 'block';
+    if (quizQuestionContainerEl) quizQuestionContainerEl.style.display = 'none';
+    if (quizNavigationEl) quizNavigationEl.style.display = 'none';
+    if (quizResultsAreaEl) quizResultsAreaEl.style.display = 'none';
+    if (quizReviewContainerEl) quizReviewContainerEl.style.display = 'none';
+    if (quizLoadingMessageEl) quizLoadingMessageEl.style.display = 'none';
+}
+
 function initializeQuizSession() {
     const langTranslations = translations[currentLanguage] || translations['de'];
     if (!currentQuizData || currentQuizData.length === 0) {
@@ -114,6 +125,8 @@ function initializeQuizSession() {
         activeQuizQuestions = [];
         return;
     }
+
+    if (startScreenEl) startScreenEl.style.display = 'none';
 
     let numQuestionsToShow = numQuestionsSelectEl.value;
     if (numQuestionsToShow === "all") {
@@ -374,12 +387,12 @@ function setupQuizEventListeners() {
     }
     if (restartQuizBtn) {
         restartQuizBtn.addEventListener('click', () => {
-            initializeQuizSession();
+            showStartScreen();
         });
     }
-    if (numQuestionsSelectEl) { // Add event listener for question number change
-        numQuestionsSelectEl.addEventListener('change', () => {
-            initializeQuizSession(); // Restart quiz with new setting
+    if (startQuizBtn) {
+        startQuizBtn.addEventListener('click', () => {
+            initializeQuizSession();
         });
     }
 }

--- a/js/translations.js
+++ b/js/translations.js
@@ -170,6 +170,7 @@ const translations = {
         tooltip_init_sensitive_td: "Empfindlich",
         quiz_numQuestionsLabel: "Anzahl der Fragen:",
         quiz_numQuestionsAll: "Alle",
+        quiz_startButton: "Quiz starten",
         quiz_reviewTitle: "Fehleranalyse",
         quiz_reviewQuestion: "Frage:",
         quiz_reviewYourAnswer: "Deine Antwort:",
@@ -359,6 +360,7 @@ const translations = {
                 // ... (alle bisherigen englischen Übersetzungen) ...
         quiz_numQuestionsLabel: "Number of Questions:",
         quiz_numQuestionsAll: "All",
+        quiz_startButton: "Start Quiz",
         quiz_reviewTitle: "Incorrect Answers Review",
         quiz_reviewQuestion: "Question:",
         quiz_reviewYourAnswer: "Your Answer:",


### PR DESCRIPTION
## Summary
- add a start screen with start button and question selection
- wire start screen events in `quiz_logic.js`
- show start screen on language change via `main.js`
- translate new `quiz_startButton` label

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684004594e688322bdb060a74cdd7730