### PR TITLE
Support GitHub PAT for quiz explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Dieses Projekt präsentiert eine interaktive Webseite, die detaillierte Einblick
     * Sofortige Erläuterungen nach falschen Antworten, sofern verfügbar.
     * Möglichkeit zur Überprüfung falsch beantworteter Fragen mit Erklärungen (sofern in den Quizdaten vorhanden).
     * Fortschrittsanzeige mit Timer.
-    * Optional: Generiere auf Knopfdruck eine LLM-basierte Erklärung zur richtigen Antwort (benötigt eigenen OpenAI API Key).
+    * Optional: Generiere auf Knopfdruck eine LLM-basierte Erklärung zur richtigen Antwort (benötigt eigenen OpenAI API Key oder GitHub PAT).
 * **Zweisprachigkeit:**
     * Einfacher Wechsel zwischen Deutsch (DE) und Englisch (EN).
     * Alle Texte, Beschriftungen und Quizfragen werden entsprechend angepasst.
@@ -82,7 +82,7 @@ Da die Quizdaten (`quiz_data_*.json`) mit `fetch` geladen werden, kann es bei lo
 * **Ergebnisse ansehen:** Nach der letzten Frage werden deine Ergebnisse angezeigt.
 * **Fehleranalyse:** Wenn du Fragen falsch beantwortet hast, erscheint ein Bereich zur Fehleranalyse, in dem deine falsche Antwort, die richtige Antwort und ggf. eine Erklärung angezeigt werden.
 * **Diagramm ansehen:** Scrolle zum Bereich "Modellfreie Vorhersage", um das Diagramm zu sehen, das MC- und TD-Methoden vergleicht. Die Beschriftungen des Diagramms ändern sich ebenfalls mit der Sprachauswahl.
-* **LLM-Erklärungen aktivieren:** Speichere deinen OpenAI API Key im Browser (z.B. via `localStorage.setItem('openaiApiKey', 'sk-...')`). Danach kannst du über den Button "Erklärung generieren" eine kurze Begründung abrufen.
+* **LLM-Erklärungen aktivieren:** Speichere entweder deinen OpenAI API Key (`localStorage.setItem('openaiApiKey', 'sk-...')`) oder ein GitHub Personal Access Token mit `models:read`-Rechten (`localStorage.setItem('githubPat', 'ghp_...')`) im Browser. Danach kannst du über den Button "Erklärung generieren" eine kurze Begründung abrufen.
 
 ## 📄 Lizenz
 

--- a/js/quiz_logic.js
+++ b/js/quiz_logic.js
@@ -112,28 +112,53 @@ function stopQuizTimer() {
 }
 
 async function fetchLLMExplanation(questionText, correctAnswerText, lang) {
-    const apiKey = localStorage.getItem('openaiApiKey');
-    if (!apiKey) throw new Error('API key missing');
+    const openaiKey = localStorage.getItem('openaiApiKey');
+    const githubPat = localStorage.getItem('githubPat');
+
+    if (!openaiKey && !githubPat) throw new Error('API key missing');
+
     const systemPrompt = lang === 'de'
         ? 'Du bist ein Tutor für Reinforcement Learning. Erkläre kurz, warum die gegebene Antwort korrekt ist.'
         : 'You are a reinforcement learning tutor. Briefly explain why the given answer is correct.';
     const userPrompt = `${questionText}\nKorrekte Antwort: ${correctAnswerText}`;
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${apiKey}`
-        },
-        body: JSON.stringify({
-            model: 'gpt-3.5-turbo',
-            messages: [
-                { role: 'system', content: systemPrompt },
-                { role: 'user', content: userPrompt }
-            ],
-            max_tokens: 120,
-            temperature: 0.7
-        })
-    });
+
+    let response;
+    if (githubPat) {
+        response = await fetch('https://models.github.ai/inference/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${githubPat}`
+            },
+            body: JSON.stringify({
+                model: 'openai/gpt-4.1-nano',
+                temperature: 1.0,
+                top_p: 1.0,
+                messages: [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'user', content: userPrompt }
+                ]
+            })
+        });
+    } else {
+        response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${openaiKey}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-3.5-turbo',
+                messages: [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'user', content: userPrompt }
+                ],
+                max_tokens: 120,
+                temperature: 0.7
+            })
+        });
+    }
+
     if (!response.ok) throw new Error('LLM request failed');
     const data = await response.json();
     return data.choices[0].message.content.trim();


### PR DESCRIPTION
## Summary
- allow using GitHub hosted models for quiz explanations
- document new PAT option in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684008ad1a408322a89d8531db6bef71